### PR TITLE
Swift null object pattern

### DIFF
--- a/src/swift/nullObject/Package.swift
+++ b/src/swift/nullObject/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "nullObject"
+)

--- a/src/swift/nullObject/README.md
+++ b/src/swift/nullObject/README.md
@@ -1,0 +1,1 @@
+# Null Object Pattern

--- a/src/swift/nullObject/Sources/nullObject/facebookLogin.swift
+++ b/src/swift/nullObject/Sources/nullObject/facebookLogin.swift
@@ -1,0 +1,7 @@
+class FacebookLogin: LoginService {
+
+    func login() -> Bool {
+        return true
+    }
+
+}

--- a/src/swift/nullObject/Sources/nullObject/googleLogin.swift
+++ b/src/swift/nullObject/Sources/nullObject/googleLogin.swift
@@ -1,0 +1,7 @@
+class GoogleLogin: LoginService {
+
+    func login() -> Bool {
+        return true
+    }
+
+}

--- a/src/swift/nullObject/Sources/nullObject/loginFactory.swift
+++ b/src/swift/nullObject/Sources/nullObject/loginFactory.swift
@@ -10,7 +10,7 @@ public struct LoginFactory {
     ]
 
     func getService(ofType type: String) -> LoginService {
-        return loginServices[type]?() ?? NullLogin()
+        return loginServices[type, default: { NullLogin() }]()
     }
 
 }

--- a/src/swift/nullObject/Sources/nullObject/loginFactory.swift
+++ b/src/swift/nullObject/Sources/nullObject/loginFactory.swift
@@ -6,6 +6,7 @@ public struct LoginFactory {
 
     private let loginServices: [String: () -> LoginService] = [
         ServiceType.facebook.rawValue: { FacebookLogin() },
+        ServiceType.google.rawValue: { GoogleLogin() },
     ]
 
     func getService(ofType type: ServiceType) -> LoginService {

--- a/src/swift/nullObject/Sources/nullObject/loginFactory.swift
+++ b/src/swift/nullObject/Sources/nullObject/loginFactory.swift
@@ -1,0 +1,15 @@
+public struct LoginFactory {
+    
+    public enum ServiceType: String {
+        case facebook, google
+    }
+
+    private let loginServices: [String: () -> LoginService] = [
+        ServiceType.facebook.rawValue: { FacebookLogin() },
+    ]
+
+    func getService(ofType type: ServiceType) -> LoginService {
+        return loginServices[type.rawValue]?() ?? NullLogin()
+    }
+
+}

--- a/src/swift/nullObject/Sources/nullObject/loginFactory.swift
+++ b/src/swift/nullObject/Sources/nullObject/loginFactory.swift
@@ -9,8 +9,8 @@ public struct LoginFactory {
         ServiceType.google.rawValue: { GoogleLogin() },
     ]
 
-    func getService(ofType type: ServiceType) -> LoginService {
-        return loginServices[type.rawValue]?() ?? NullLogin()
+    func getService(ofType type: String) -> LoginService {
+        return loginServices[type]?() ?? NullLogin()
     }
 
 }

--- a/src/swift/nullObject/Sources/nullObject/loginService.swift
+++ b/src/swift/nullObject/Sources/nullObject/loginService.swift
@@ -1,0 +1,5 @@
+protocol LoginService {
+
+    func login() -> Bool
+    
+}

--- a/src/swift/nullObject/Sources/nullObject/nullLogin.swift
+++ b/src/swift/nullObject/Sources/nullObject/nullLogin.swift
@@ -1,7 +1,7 @@
 class NullLogin: LoginService {
 
     func login() -> Bool {
-        return true
+        return false
     }
 
 }

--- a/src/swift/nullObject/Sources/nullObject/nullLogin.swift
+++ b/src/swift/nullObject/Sources/nullObject/nullLogin.swift
@@ -1,0 +1,7 @@
+class NullLogin: LoginService {
+
+    func login() -> Bool {
+        return true
+    }
+
+}

--- a/src/swift/nullObject/Sources/nullObject/nullObject.swift
+++ b/src/swift/nullObject/Sources/nullObject/nullObject.swift
@@ -1,2 +1,0 @@
-public struct NullObject {
-}

--- a/src/swift/nullObject/Sources/nullObject/nullObject.swift
+++ b/src/swift/nullObject/Sources/nullObject/nullObject.swift
@@ -1,0 +1,2 @@
+public struct NullObject {
+}

--- a/src/swift/nullObject/Tests/LinuxMain.swift
+++ b/src/swift/nullObject/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import nullObjectTests
+
+var tests = [XCTestCaseEntry]()
+tests += nullObjectTests.allTests()
+XCTMain(tests)

--- a/src/swift/nullObject/Tests/nullObjectTests/XCTestManifests.swift
+++ b/src/swift/nullObject/Tests/nullObjectTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !os(macOS)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(NullObjectTests.allTests),
+    ]
+}
+#endif

--- a/src/swift/nullObject/Tests/nullObjectTests/nullObjectTests.swift
+++ b/src/swift/nullObject/Tests/nullObjectTests/nullObjectTests.swift
@@ -3,13 +3,15 @@ import XCTest
 
 final class NullObjectTests: XCTestCase {
 
-    func testSomething() {
-        // let sut = fizz()
-        // let result = sut.getResult(3)
-        // XCTAssertEqual(result, "fizz")
+    func testFacebookLoginSuccess() {
+        let sut = LoginFactory()
+        let loginService = sut.getService(ofType: LoginFactory.ServiceType.facebook)
+        let loginSuccess = loginService.login()
+        XCTAssertTrue(loginSuccess)
     }
 
     static var allTests = [
-        ("testSomething", testSomething),
+        ("testFacebookLoginSuccess", testFacebookLoginSuccess),
     ]
+    
 }

--- a/src/swift/nullObject/Tests/nullObjectTests/nullObjectTests.swift
+++ b/src/swift/nullObject/Tests/nullObjectTests/nullObjectTests.swift
@@ -18,15 +18,16 @@ final class NullObjectTests: XCTestCase {
     }
 
     func testNullLoginFailure() {
-        // let sut = LoginFactory()
-        // let loginService = sut.getService(ofType: LoginFactory.ServiceType.google)
-        // let loginSuccess = loginService.login()
-        // XCTAssertTrue(loginSuccess)
+        let sut = LoginFactory()
+        let loginService = sut.getService(ofType: "Github")
+        let loginSuccess = loginService.login()
+        XCTAssertFalse(loginSuccess)
     }
 
     static var allTests = [
         ("testFacebookLoginSuccess", testFacebookLoginSuccess),
         ("testGoogleLoginSuccess", testGoogleLoginSuccess),
+        ("testNullLoginFailure", testNullLoginFailure),
     ]
 
 }

--- a/src/swift/nullObject/Tests/nullObjectTests/nullObjectTests.swift
+++ b/src/swift/nullObject/Tests/nullObjectTests/nullObjectTests.swift
@@ -5,16 +5,23 @@ final class NullObjectTests: XCTestCase {
 
     func testFacebookLoginSuccess() {
         let sut = LoginFactory()
-        let loginService = sut.getService(ofType: LoginFactory.ServiceType.facebook)
+        let loginService = sut.getService(ofType: LoginFactory.ServiceType.facebook.rawValue)
         let loginSuccess = loginService.login()
         XCTAssertTrue(loginSuccess)
     }
 
     func testGoogleLoginSuccess() {
         let sut = LoginFactory()
-        let loginService = sut.getService(ofType: LoginFactory.ServiceType.google)
+        let loginService = sut.getService(ofType: LoginFactory.ServiceType.google.rawValue)
         let loginSuccess = loginService.login()
         XCTAssertTrue(loginSuccess)
+    }
+
+    func testNullLoginFailure() {
+        // let sut = LoginFactory()
+        // let loginService = sut.getService(ofType: LoginFactory.ServiceType.google)
+        // let loginSuccess = loginService.login()
+        // XCTAssertTrue(loginSuccess)
     }
 
     static var allTests = [

--- a/src/swift/nullObject/Tests/nullObjectTests/nullObjectTests.swift
+++ b/src/swift/nullObject/Tests/nullObjectTests/nullObjectTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import nullObject
+
+final class NullObjectTests: XCTestCase {
+
+    func testSomething() {
+        // let sut = fizz()
+        // let result = sut.getResult(3)
+        // XCTAssertEqual(result, "fizz")
+    }
+
+    static var allTests = [
+        ("testSomething", testSomething),
+    ]
+}

--- a/src/swift/nullObject/Tests/nullObjectTests/nullObjectTests.swift
+++ b/src/swift/nullObject/Tests/nullObjectTests/nullObjectTests.swift
@@ -10,8 +10,16 @@ final class NullObjectTests: XCTestCase {
         XCTAssertTrue(loginSuccess)
     }
 
+    func testGoogleLoginSuccess() {
+        let sut = LoginFactory()
+        let loginService = sut.getService(ofType: LoginFactory.ServiceType.google)
+        let loginSuccess = loginService.login()
+        XCTAssertTrue(loginSuccess)
+    }
+
     static var allTests = [
         ("testFacebookLoginSuccess", testFacebookLoginSuccess),
+        ("testGoogleLoginSuccess", testGoogleLoginSuccess),
     ]
-    
+
 }


### PR DESCRIPTION
Adds an example of the "Null Object Pattern".

There is a factory object responsible for building a login service based on a string passed by its client and if there is no login service available associated to that string, it returns a null object that does not execute a login but it fails rather than returning a nil object and forcing the client to check for it.